### PR TITLE
Topic/minor fixes

### DIFF
--- a/lib/Parallel/Prefork.pm
+++ b/lib/Parallel/Prefork.pm
@@ -191,7 +191,7 @@ sub _action_for {
 sub wait_all_children {
     my $self = shift;
     $self->{_no_adjust_until} = undef;
-    while (%{$self->{worker_pids}}) {
+    while (keys %{$self->{worker_pids}}) {
         if (my ($pid) = $self->_wait(1)) {
             if (delete $self->{worker_pids}{$pid}) {
                 $self->_on_child_reap($pid, $?);


### PR DESCRIPTION
While debugging my preforking app, I noticed you were evaluating a hash in scalar context to check if it's empty - while this "works", it relies on mostly undocumented behaviour, and would be better rewritten to use keys().

(also, I fixed some typos.) :)

great module; thank you!
