### PR TITLE
avoid wait_all_children with timeout is blocking forever

### DIFF
--- a/t/07-wait-all-children-does-not-block.t
+++ b/t/07-wait-all-children-does-not-block.t
@@ -1,0 +1,69 @@
+#! /usr/bin/perl
+
+use strict;
+use warnings;
+
+use Fcntl qw/:flock/;
+use File::Temp qw/tempfile/;
+use Test::More tests => 1;
+use Time::HiRes qw/sleep/;
+
+use Parallel::Prefork;
+
+my $pid = fork;
+die $! unless defined $pid;
+
+if ($pid) {
+    my $timeout = 0;
+    local $SIG{ALRM} = sub { $timeout = 1; kill 'INT', $pid };
+    alarm 5;
+    until(waitpid $pid, 0) {}
+    alarm 0;
+    ok !$timeout, "wait_all_children does not block";
+} else {
+
+    my ($fh, $filename) = tempfile;
+    syswrite $fh, '0', 1;
+    close $fh;
+
+    my $manager_pid = $$;
+
+    my $pm = Parallel::Prefork->new({
+        max_workers   => 30,
+        fork_delay    => 0,
+    });
+
+    until ($pm->signal_received) {
+        $pm->start and next;
+
+        open my $fh, '+<', $filename
+            or die "failed to open temporary file: $filename: ";
+        flock $fh, LOCK_EX;
+        sysread $fh, my $worker_count, 10;
+        $worker_count++;
+        seek $fh, 0, 0;
+        syswrite $fh, $worker_count, length($worker_count);
+        flock $fh, LOCK_UN;
+        close $fh;
+
+        if ($worker_count == $pm->max_workers) {
+            kill 'TERM', $manager_pid;
+        }
+
+        # wait for SIGTERM
+        my $rcv = 0;
+        eval {
+            local $SIG{TERM} = sub { $rcv = 1; die "SIGTERM" };
+            sleep(100);
+        };
+        die $@ if $@ && !$rcv;
+
+        # sleep 1 +/- 0.01 seconds
+        sleep(0.99 + 0.02 * $worker_count / $pm->max_workers);
+        $pm->finish;
+    }
+
+    $pm->wait_all_children(1);
+    $pm->wait_all_children();
+    exit 0;
+}


### PR DESCRIPTION
I call wait_all_children with timeout, but sometimes it blocks forever.

waitpidが終了した子プロセスのpidを返す→Parallel::Preforkが管理している子プロセス一覧を更新する、という処理の途中でタイムアウトが発生すると、子プロセス一覧が正常に更新されないため、すでに終了したはずの子プロセスを永遠に待ち続けるようです。

alartを使用した方法では回避が難しかったため、0.16のwaitpid+sleepを使った方式に戻し、テストが通るよう微調整しました。
waitpid+sleepから今の方式に切り替わった理由を把握しきれていないのですが、この修正で問題解決になっていますでしょうか？