### PR TITLE
switch to List::Util 1.45 for uniq function

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,7 @@ all_from 'lib/Parallel/Prefork.pm';
 readme_from 'lib/Parallel/Prefork.pm';
 
 requires 'Class::Accessor::Lite' => 0.04;
-requires 'List::MoreUtils';
+requires 'List::Util' => 1.45;
 requires 'Proc::Wait3' => 0.03;
 requires 'Scope::Guard';
 requires 'Signal::Mask';

--- a/lib/Parallel/Prefork/SpareWorkers.pm
+++ b/lib/Parallel/Prefork/SpareWorkers.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use Exporter qw(import);
 
-use List::MoreUtils qw(uniq);
+use List::Util qw(uniq);
 
 use base qw/Parallel::Prefork/;
 


### PR DESCRIPTION
`List::MoreUtils` has an overly complicated install process.  List::Util 1.45 also comes with a `uniq` function and is in core (for that version or later) for recent versions of Perl.